### PR TITLE
Update beaconResultsets.json

### DIFF
--- a/responses/sections/beaconResultsets.json
+++ b/responses/sections/beaconResultsets.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "description": "Section of the response that includes the record level details grouped in resultsets.\n",
+  "description": "Section of the response that includes the record level details grouped in Resultsets.\n",
   "type": "object",
   "properties": {
     "$schema": {
@@ -18,8 +18,8 @@
     "resultSetInstance": {
       "type": "object",
       "oneOf": [
-        { "$ref": "../sections/beaconEmptyResultset.json" },
-        { "$ref": "../sections/beaconNonEmptyResultset.json" }
+        { "$ref": "./beaconEmptyResultset.json" },
+        { "$ref": "./beaconNonEmptyResultset.json" }
       ]
     }
   },


### PR DESCRIPTION
Fixing local paths.

Note: There is an inconsistent use of "...resultSet..." and "...resultset...", i.e. camelizing of separate words vs. single composed word. The original use was "result_sets" / "resultSets"; this should be aligned throughout the schemas.