### PR TITLE
extendedInfo -> info

### DIFF
--- a/responses/beaconCoreResponse.json
+++ b/responses/beaconCoreResponse.json
@@ -20,7 +20,7 @@
         }
       ]
     },
-    "extendedInfo": {
+    "info": {
       "description": "Additional details that could be of interest. Provided to clearly enclose any attribute that is not part of the Beacon specification.\n",
       "$ref": "../common/beaconCommonComponents.json#/definitions/Info"
     },

--- a/responses/examples/beaconEntryTypeCoreResponse-MAX-example.json
+++ b/responses/examples/beaconEntryTypeCoreResponse-MAX-example.json
@@ -21,7 +21,7 @@
     "exists": true,
     "numTotalResults": 25355
   },
-  "extendedInfo": {
+  "info": {
     "someInterestingStuff": "this is the interesting stuff"
   },
   "beaconHandovers":[

--- a/responses/sections/beaconEmptyResultset.json
+++ b/responses/sections/beaconEmptyResultset.json
@@ -19,7 +19,7 @@
       "type": "string",
       "enum": ["false"]
     },
-    "extendedInfo": {
+    "info": {
       "description": "Additional details that could be of interest about the Resultset. Provided to clearly enclose any attribute that is not part of the Beacon specification.\n",
       "type": "object"
     }

--- a/responses/sections/beaconNonEmptyResultset.json
+++ b/responses/sections/beaconNonEmptyResultset.json
@@ -31,7 +31,7 @@
       "description": "List of handovers that apply to this resultset, not to the whole Beacon or to a result in particular.\n",
       "$ref": "../../common/beaconCommonComponents.json#/definitions/ListOfHandovers"
     },
-    "extendedInfo": {
+    "info": {
       "description": "Additional details that could be of interest about the Resultset. Provided to clearly enclose any attribute that is not part of the Beacon specification.\n",
       "type": "object"
     },


### PR DESCRIPTION
There is an inconsistent use of `extendedInfo` in contrast to the previous/usual/more frequent `info` property name. Reverted to `info` throughout.