### PR TITLE
setType instead of type in resultSets

### DIFF
--- a/responses/sections/beaconEmptyResultset.json
+++ b/responses/sections/beaconEmptyResultset.json
@@ -9,7 +9,7 @@
       "type": "string",
       "example": "datasetA\n"
     },
-    "type": {
+    "setType": {
       "description": "Entry type of resultSet. It SHOULD MATCH an entry type declared as collection in the Beacon configuration.\n",
       "type": "string",
       "default": "dataset"

--- a/responses/sections/beaconNonEmptyResultset.json
+++ b/responses/sections/beaconNonEmptyResultset.json
@@ -13,7 +13,7 @@
       "type": "string",
       "example": "datasetA\n"
     },
-    "type": {
+    "setType": {
       "description": "Entry type of resultSet. It SHOULD MATCH an entry type declared as collection in the Beacon configuration.\n",
       "type": "string",
       "default": "dataset"


### PR DESCRIPTION
`type` is a keyword and should be avoided for property names (in fact breaks some code here...).