### PR TITLE
splitting Core -> Count, Boolean responses

### DIFF
--- a/responses/beaconBooleanResponse.json
+++ b/responses/beaconBooleanResponse.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "description": "Beacon response that includes record level details, grouped in Resultsets.\n",
+  "description": "Complete definition for a minimal response that does *only* a `boolean` exists true|false answer.\n",
   "type": "object",
   "required": ["meta", "responseSummary"],
   "properties": {
@@ -9,9 +9,8 @@
       "$ref": "./sections/beaconResponseMeta.json"
     },
     "responseSummary": {
-      "description": "Response summary, including Boolean and optionally results count.\n",
-      "$ref": "./sections/beaconSummaryResponseSection.json"
-
+      "description": "Boolean (true/false) response section.\n",
+      "$ref": "./sections/beaconBooleanResponseSection.json"
     },
     "extendedInfo": {
       "description": "Additional details that could be of interest. Provided to clearly enclose any attribute that is not part of the Beacon specification.\n",
@@ -20,9 +19,6 @@
     "beaconHandovers": {
       "description": "List of handovers that apply to the whole response, not to any resultset or result in particular.\n",
       "$ref": "../common/beaconCommonComponents.json#/definitions/ListOfHandovers"
-    },
-    "resultSets": {
-      "description": "Data responses wrapped for individual resultSets (e.g. dataset specific).",
-      "$ref": "./sections/beaconResultsets.json"
     }
+  }
 }

--- a/responses/beaconCountResponse.json
+++ b/responses/beaconCountResponse.json
@@ -9,16 +9,9 @@
       "$ref": "./sections/beaconResponseMeta.json"
     },
     "responseSummary": {
-      "anyOf": [
-        {
-          "description": "Boolean (true/false) response section.\n",
-          "$ref": "./sections/beaconBooleanResponseSection.json"
-        },
-        {
-          "description": "Total number of results section.\n",
-          "$ref": "./sections/beaconCountResponseSection.json"
-        }
-      ]
+      "description": "Response summary, including Boolean and optionally results count.\n",
+      "$ref": "./sections/beaconSummaryResponseSection.json"
+
     },
     "extendedInfo": {
       "description": "Additional details that could be of interest. Provided to clearly enclose any attribute that is not part of the Beacon specification.\n",

--- a/responses/examples/beaconEntryTypeCoreResponse-MAX-example.json
+++ b/responses/examples/beaconEntryTypeCoreResponse-MAX-example.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../beaconCoreResponse.json",
+  "$schema": "../beaconCountResponse.json",
   "meta": {
     "beaconId":"org.example.beacon.v2",
     "apiVersion": "v2.0",

--- a/responses/examples/beaconEntryTypeCoreResponse-MIN-example.json
+++ b/responses/examples/beaconEntryTypeCoreResponse-MIN-example.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../beaconCoreResponse.json",
+  "$schema": "../beaconBooleanResponse.json",
   "meta": {
     "beaconId":"org.example.beacon.v2",
     "apiVersion": "v2.0",

--- a/responses/sections/beaconSummaryResponseSection.json
+++ b/responses/sections/beaconSummaryResponseSection.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "description": "Beacon results summary section.\n",
+  "type": "object",
+  "properties": {
+    "exists": {
+      "description": "Indicator of whether any entry was observed. This should be non-null, unless there was an error, in which case an error response is expected instead of this one.",
+      "$ref": "../../common/beaconCommonComponents.json#/definitions/Exists"
+    },
+    "numTotalResults": {
+      "description": "Total number of results.\n",
+      "$ref": "../../common/beaconCommonComponents.json#/definitions/NumTotalResults"
+    }
+  },
+  "required": ["exists"]
+}


### PR DESCRIPTION
Optional: rename Boolean back to Core
Additionally, the beaconResultsetsResponse was reshaped to be just in a standard format (basically the count response with additional resultSets).