### PR TITLE
Scope parameter addition to filters requests

### DIFF
--- a/requests/examples-fullDocuments/beaconRequestBody-MAX-example.json
+++ b/requests/examples-fullDocuments/beaconRequestBody-MAX-example.json
@@ -13,7 +13,10 @@
       }
     },
     "filters": [ 
-      {"id": "EFO:0001212"}
+      {
+        "id": "EFO:0001212",
+        "scope": "biosamples"
+      }
     ],
     "includeResultsetResponses": "HIT",
     "pagination": {

--- a/requests/examples-sections/filteringTerms-example.json
+++ b/requests/examples-sections/filteringTerms-example.json
@@ -5,15 +5,18 @@
     {
       "id": "HP:0002664",
       "includeDescendantTerms": true,
-      "similarity": "exact"
+      "similarity": "exact",
+      "scope": "biosamples"
     },
     {
       "id": "age",
       "operator": ">=",
-      "value": "P70Y"
+      "value": "P70Y",
+      "scope": "individuals"
     },
     {
-      "id": "demographic.ethnicity:asian"
+      "id": "demographic.ethnicity:asian",
+      "scope": "cohorts"
     }
   ]
 }

--- a/requests/filteringTerms.json
+++ b/requests/filteringTerms.json
@@ -37,6 +37,11 @@
           "enum": ["exact", "high", "medium", "low"],
           "default": "exact",
           "description": "Allow the Beacon to return results which do not match the filter exactly, but do match to a certain degree of similarity. The Beacon defines the semantic similarity model implemented and how to apply the thresholds of 'high', 'medium' and 'low' similarity.\n"
+        },
+        "scope": {
+          "type": "string",
+          "description": "The entry type to which the filter applies",
+          "example": "biosamples"
         }
       }
     },
@@ -61,6 +66,11 @@
           "type": "string",
           "description": "Alphanumeric search term to be used within the query which can contain wildcard characters (%) to denote any number of unknown characters.  Values can be assocatied with units if applicable.\n",
           "example": "P70Y"
+        },
+        "scope": {
+          "type": "string",
+          "description": "The entry type to which the filter applies",
+          "example": "biosamples"
         }
       }
     },
@@ -73,6 +83,11 @@
           "type": "string",
           "description": "Custom filter terms should contain a unique identifier.\n",
           "example": "demographic.ethnicity:asian"
+        },
+        "scope": {
+          "type": "string",
+          "description": "The entry type to which the filter applies",
+          "example": "biosamples"
         }
       }
     }


### PR DESCRIPTION
Updated schemas and examples to include the `scope` parameter for filters within the request body.

I am unsure how the schemas should be edited for GET requests so I have only amended in terms of POST requests but happy to amend with guidance.