### PR TITLE
Resource object addition to the /filtering_terms endpoint

### DIFF
--- a/responses/examples-fullDocuments/beaconFilteringTermsResponse-example.json
+++ b/responses/examples-fullDocuments/beaconFilteringTermsResponse-example.json
@@ -7,14 +7,34 @@
       { "map": "beacon-map-v2.0.0-draft.3" }
     ]
   },
-  "response": 
-    [
+  "response": {
+   "resources": [
       {
-        "type": "ontology",
-        "id": "DUO:0000006",
-        "label": "health or medical or biomedical research",
-        "version": "2021-02-23"
+        "id": "hp",
+        "name": "Human Phenotype Ontology",
+        "url": "http://purl.obolibrary.org/obo/hp.owl",
+        "version": "27-03-2020",
+        "namespacePrefix": "HP",
+        "iriPrefix": "http://purl.obolibrary.org/obo/HP_"
       }
     ],
+    "filteringTerms": [
+      {
+        "type": "numeric",
+        "id": "PATO:0000011",
+        "label": "age"
+      },
+      {
+        "type": "Human Phenotype Ontology",
+        "id": "HP:0008773",
+        "label": "Aplasia/Hypoplasia of the middle ear"
+      },
+      {
+        "type": "custom",
+        "id": "ownsIPhone",
+        "label": "Individuals associated with this term owns an IPhone"
+      }
+    ]
+  },
   "info": {}
 }

--- a/responses/sections/beaconFilteringTermsResults.json
+++ b/responses/sections/beaconFilteringTermsResults.json
@@ -17,13 +17,8 @@
       }
     }
   }
-  "items": {
-    "$ref": "#/definitions/FilteringTerm"
-  }
-  
-  "description": "Filtering terms and ontology resources utilised in this Beacon.\n",
-,
 
+  
   "definitions": {
     "FilteringTerm": {
       "type": "object",

--- a/responses/sections/beaconFilteringTermsResults.json
+++ b/responses/sections/beaconFilteringTermsResults.json
@@ -1,11 +1,28 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "description": "Filtering terms available in this Beacon.\n",
-  "type": "array",
+  "description": "Filtering terms and ontology resources utilised in this Beacon.\n",
+  "type": "object",
+  "properties": {
+    "resources":{
+      "type": "array",
+      "description": "Ontology resources defined externally to this beacon implementation"
+      "items": {
+        "$ref": "#/definitions/Resource"  
+      }
+    },
+    "filteringTerms": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/FilteringTerm"
+      }
+    }
+  }
   "items": {
     "$ref": "#/definitions/FilteringTerm"
-  },
-  "minItems": 0,
+  }
+  
+  "description": "Filtering terms and ontology resources utilised in this Beacon.\n",
+,
 
   "definitions": {
     "FilteringTerm": {
@@ -29,8 +46,52 @@
           "example": "Aplasia/Hypoplasia of the middle ear"
         }
       }
+    },
+    "Resource": {
+      "type": "object",
+      "description": "implementation of phenopackets resource object to describe ontology resources, full documentation found https://phenopackets-schema.readthedocs.io/en/latest/resource.html",
+      "required": ["id"],
+      "properties":{
+        "id": {
+          "type": "string",
+          "description": "OBO ID representing the resource",
+          "example": "hp"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the ontology referred to by the id element",
+          "example": "Human Phenotype Ontology"
+        },
+        "url": {
+          "type": "string",
+          "description": "Uniform Resource Locator of the resource",
+          "example": "http://purl.obolibrary.org/obo/hp.owl"
+        },
+        "version": {
+          "type": "string",
+          "description": "The version of the resource or ontology used to make the annotation",
+          "example": "17-06-2019"
+        },
+        "nameSpacePrefix": {
+          "type": "string",
+          "description": "The prefix used in the CURIE of an OntologyClass",
+          "example": "HP"
+        },
+        "iriPrefix": {
+          "type": "string",
+          "description": "The full Internationalized Resource Identifier (IRI) prefix",
+          "example": "http://purl.obolibrary.org/obo/HP_"
+        }
+      }
     }
   },
+
+
+   OntologyResource:
+        iriPrefix:
+          description: The full Internationalized Resource Identifier (IRI) prefix
+          type: string
+          example: http://purl.obolibrary.org/obo/HP_
 
   "additionalProperties": true
 }

--- a/responses/sections/beaconFilteringTermsResults.json
+++ b/responses/sections/beaconFilteringTermsResults.json
@@ -44,7 +44,7 @@
     },
     "Resource": {
       "type": "object",
-      "description": "implementation of phenopackets resource object to describe ontology resources, full documentation found https://phenopackets-schema.readthedocs.io/en/latest/resource.html",
+      "description": "implementation of phenopackets resource object to describe ontology resources, full documentation found https://phenopacket-schema.readthedocs.io/en/latest/resource.html",
       "required": ["id"],
       "properties":{
         "id": {

--- a/responses/sections/beaconFilteringTermsResults.json
+++ b/responses/sections/beaconFilteringTermsResults.json
@@ -44,7 +44,7 @@
     },
     "Resource": {
       "type": "object",
-      "description": "implementation of phenopackets resource object to describe ontology resources, full documentation found https://phenopacket-schema.readthedocs.io/en/latest/resource.html",
+      "description": "Description of an ontology resource defined externally to this beacon implementation, such as MeSH or EFO, based on the phenopackets resource object (https://phenopacket-schema.readthedocs.io/en/latest/resource.html)",
       "required": ["id"],
       "properties":{
         "id": {

--- a/responses/sections/beaconFilteringTermsResults.json
+++ b/responses/sections/beaconFilteringTermsResults.json
@@ -16,7 +16,7 @@
         "$ref": "#/definitions/FilteringTerm"
       }
     }
-  }
+  },
 
   
   "definitions": {
@@ -80,13 +80,5 @@
       }
     }
   },
-
-
-   OntologyResource:
-        iriPrefix:
-          description: The full Internationalized Resource Identifier (IRI) prefix
-          type: string
-          example: http://purl.obolibrary.org/obo/HP_
-
   "additionalProperties": true
 }

--- a/responses/sections/beaconFilteringTermsResults.json
+++ b/responses/sections/beaconFilteringTermsResults.json
@@ -5,7 +5,7 @@
   "properties": {
     "resources":{
       "type": "array",
-      "description": "Ontology resources defined externally to this beacon implementation"
+      "description": "Ontology resources defined externally to this beacon implementation",
       "items": {
         "$ref": "#/definitions/Resource"  
       }


### PR DESCRIPTION
Addition of the phenopackets resource object to the `/filtering_terms` endpoint response allowing beacon implementers the ability to declare exactly which ontologies they are utilising and the versions.