### PR TITLE
Separating CURIE in ontology term for reuse

### DIFF
--- a/common/ontologyTerm.json
+++ b/common/ontologyTerm.json
@@ -5,6 +5,15 @@
   "type": "object",
   "properties": {
     "id": {
+        "$ref": "#/definitions/CURIE"
+    },
+    "label": {
+      "type": "string",
+      "description": "The text that describes the term. By default it could be the preferred text of the term, but is it acceptable to customize it for a clearer description and understanding of the term in an specific context."
+    }
+  },
+  "definitions": {
+    "CURIE": {
       "pattern": "^\\w[^:]+:.+$",
       "type": "string",
       "description": "A CURIE identifier for an ontology term.",
@@ -14,10 +23,6 @@
         "orcid:0000-0003-3463-0775",
         "PMID:15254584"
       ]
-    },
-    "label": {
-      "type": "string",
-      "description": "The text that describes the term. By default it could be the preferred text of the term, but is it acceptable to customize it for a clearer description and understanding of the term in an specific context."
     }
   },
   "required": ["id"],


### PR DESCRIPTION
I've separated the CURIE definition inside the OntologyTerm for it to be reusable.
I've been considering to add it to the commonComponents,json, but I believed that this could encourage to use "just CURIEs" instead of complete ontology term definitions. Having CURIE inside the ontologyTerm.json could make clear that the ontology term is there and reinforce the GA4GH consensus.