### PR TITLE
Syncing conf filterTerms w request filterTerms

### DIFF
--- a/configuration/examples/beaconConfigurationFilteringTerms-example.json
+++ b/configuration/examples/beaconConfigurationFilteringTerms-example.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../filteringTermsSchema.json",
+  "filteringTerms": [
+    { 
+      "ftType": "alfanumeric",
+      "id": "age",
+      "scope": "individual"
+    },
+    {
+      "ftType": "ontologyTerm",
+      "id": "HP:0002664",
+      "label": "Neoplasm",
+      "scope": "biosample"
+    },
+    {
+      "ftType": "alfanumeric",
+      "id": "NCIT:C100094",
+      "label": "HGNC gene name",
+      "scope": "genomicVariant"
+    }
+  ]
+}

--- a/configuration/examples/beaconConfigurationFilteringTerms-example.json
+++ b/configuration/examples/beaconConfigurationFilteringTerms-example.json
@@ -2,7 +2,7 @@
   "$schema": "../filteringTermsSchema.json",
   "filteringTerms": [
     { 
-      "ftType": "alfanumeric",
+      "ftType": "alphanumeric",
       "id": "age",
       "scope": "individual"
     },
@@ -13,7 +13,7 @@
       "scope": "biosample"
     },
     {
-      "ftType": "alfanumeric",
+      "ftType": "alphanumeric",
       "id": "NCIT:C100094",
       "label": "HGNC gene name",
       "scope": "genomicVariant"

--- a/configuration/filteringTermsSchema.json
+++ b/configuration/filteringTermsSchema.json
@@ -8,11 +8,47 @@
       "description": "List of filtering terms that could be used to filter this concept in this instance of Beacon.",
       "type": "array",
       "items": {
-        "$ref": "../common/ontologyTerm.json"
+        "$ref": "#/definitions/FilterTerm"
       },
       "minItems": 0
     }
   },
-  "required": ["filteringTerms"],
-  "additionalProperties": true
+  "definitions": {
+    "FilterTerm": {
+      "type":"object",
+      "properties": {
+        "ftType": {
+          "description": "Type of filter term, according to the 'request/filteringTerms.json' schema. \n* 'ontologyTerm' is an term that belongs to a tree of concepts, hence suitable to operations like 'query by similarity' or 'include all descendants'. Many ontology terms are a value in itself (like 'female'), hence no further information is required to solve the query.\n* 'alfanumeric' is a field or an ontology term (like 'age') that requires a value to complete the intended query. Only attributes of known schemas SHOULD be used here. For attributes that are not part of the known schemas, the 'custom' type MUST be used.\n* 'custom' is anything that doesn't fit the previous categories and mainly for custom dictionaries that have no ontology nor a corresponding attribute in the known schemas. Usually only makes sense for close partners that are familiar with the custom dictionary.\n",
+          "type":"string",
+          "enum": ["ontologyTerm", "alfanumeric", "custom"]
+        },
+        "id": {
+          "type": "string",
+          "description": "Term ID, Field ID or custom term string. For Term ID use CURIE syntax where possible.",
+          "examples": [
+            "HP:0002664",
+            "age",
+            "demographic.ethnicity:subsaharian"
+          ]
+        },
+        "label": {
+          "type": "string",
+          "description": "For Term ID use the ontology label. For other ftTypes add a readable description",
+          "examples": [
+            "Neoplasm",
+            "age in days",
+            "All regions to the South os the Sahara Desert."
+          ]
+        },
+        "scope": {
+          "type": "string",
+          "description": "The entry type to which the filter applies",
+          "examples": ["biosample", "individual"]
+        }
+      },
+      "required": ["ftType", "id"]
+    }
+  }
+  , "required": ["filteringTerms"]
+  , "additionalProperties": true
 }


### PR DESCRIPTION
The filtering terms are used in two different places in the Framework:

1. In the request, leveraging the `request/filteringTerms.json` schema, which includes the operators and so on.
2. In the configuration and every entry type, that should include a simplified version to be consumed by the Beacon clients, just to know which filter terms are available. The later are defined using the `configuration/filteringTermsSchema.json` file.
Currently, the latter is still defined as an array of `ontologyTerm `objects, which is no longer correct.
This PR is meant to amend that including one schema for that description of the filter terms and some examples of documents compliant with such schema.