### PR TITLE
rename 'RelatedEndpoints' to 'RelatedEndpoint'

### DIFF
--- a/configuration/beaconConfigurationSchema.json
+++ b/configuration/beaconConfigurationSchema.json
@@ -46,6 +46,7 @@
   "definitions": {
     "EntryTypes": {
       "description": "This is a dictionary of the entry types implemented in this Beacon instance.",
+      "type": "object",
       "additionalProperties": {
         "type": "object",
         "$ref": "./entryTypeDefinition.json"

--- a/configuration/beaconMapSchema.json
+++ b/configuration/beaconMapSchema.json
@@ -48,14 +48,14 @@
           "description": "Optional. A list describing additional endpoints implemented by this Beacon instance for that entry type. Additional details on the endpoint parameters, supported HTTP verbs, etc. could be obtained by parsing the OpenAPI definition referenced in the `openAPIEndpointsDefinition` attribute.",
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/RelatedEndpoints"
+            "$ref": "#/definitions/RelatedEndpoint"
           },
           "minProperties": 0
         }
       },
       "required": ["entryType", "rootUrl"]
     },
-    "RelatedEndpoints": {
+    "RelatedEndpoint": {
       "type": "object",
       "properties": {
         "url": {


### PR DESCRIPTION
#45 'RelatedEndpoint' is singular.