### PR TITLE
making numTotalResults mandatory for count responses

### DIFF
--- a/responses/sections/beaconCountResponseSection.json
+++ b/responses/sections/beaconCountResponseSection.json
@@ -12,5 +12,5 @@
       "$ref": "../../common/beaconCommonComponents.json#/definitions/NumTotalResults"
     }
   },
-  "required": ["exists"]
+  "required": ["exists","numTotalResults"]
 }


### PR DESCRIPTION
This is to correct the false duplication found in #60 