### PR TITLE
De-snakify pagination properties

### DIFF
--- a/common/beaconCommonComponents.json
+++ b/common/beaconCommonComponents.json
@@ -74,15 +74,15 @@
         "limit": {
           "$ref": "#/definitions/Limit"
         },
-        "current_page": {
+        "currentPage": {
           "description": "Token of the returned page. To be used only in the response to allow the client to check if the returned page is the one requested.",
           "$ref": "#/definitions/PageToken"
         },
-        "next_page": {
+        "nextPage": {
           "description": "Token of the next page. Used to navigate forward. If empty, it is assumed that no more pages are available",
           "$ref": "#/definitions/PageToken"
         },
-        "previous_page": {
+        "previousPage": {
           "description": "Token of the previous page. Used to navigate backwards. If empty, it is assumed that the current page is the first one.",
           "$ref": "#/definitions/PageToken"
         }


### PR DESCRIPTION
current_page ... etc. didn't follow the camelCase paradigm.

Apart from this it would be clearer to use something like:

* `currentPageToken`, `nextPageToken`, `previousPageToken` in the response
* `pageToken` in the request

... but I'll leave this to others `¯\_(ツ)_/¯`