### PR TITLE
securityLevels in configuration default as array

### DIFF
--- a/configuration/beaconConfigurationSchema.json
+++ b/configuration/beaconConfigurationSchema.json
@@ -31,8 +31,7 @@
           "type": "array",
           "items": {
             "enum": ["PUBLIC", "REGISTERED", "CONTROLLED"],
-            "default": "CONTROLLED",
-            "$comment": "TO DO: Check if values can be made unique."
+            "default": ["CONTROLLED"]
           }
         }
       }


### PR DESCRIPTION
securityLevels in configuration is defined as array but was string in default.

Removed: "$comment": "TO DO: Check if values can be made unique."

... which should better be an issue (if still needed).